### PR TITLE
Better explanation on how to properly build the Base URL

### DIFF
--- a/articles/data-factory/connector-sharepoint-online-list.md
+++ b/articles/data-factory/connector-sharepoint-online-list.md
@@ -246,7 +246,7 @@ You can copy file from SharePoint Online by using **Web activity** to authentica
 3. Chain with a **Copy activity** with HTTP connector as source to copy SharePoint Online file content:
 
     - HTTP linked service:
-        - **Base URL**: `https://[site-url]/_api/web/GetFileByServerRelativeUrl('[relative-path-to-file]')/$value`. Replace the site URL and relative path to file. Sample relative path to file as `/sites/site2/Shared Documents/TestBook.xlsx`.
+        - **Base URL**: `https://[site-url]/_api/web/GetFileByServerRelativeUrl('[relative-path-to-file]')/$value`. Replace the site URL and relative path to file. Make sure to include the SharePoint site url along the Domain name. Such as: `https://[sharepoint-domain-name].sharepoint.com/sites/[sharepoint-site]/_api/web/GetFileByServerRelativeUrl('/sites/[sharepoint-site]/[relative-path-to-file]')/$value`.
         - **Authentication type:** Anonymous *(to use the Bearer token configured in copy activity source later)*
     - Dataset: choose the format you want. To copy file as-is, select "Binary" type.
     - Copy activity source:


### PR DESCRIPTION
GOAL:

Better explanation on how to properly build the Base URL for downloading a file from SharePoint Online.

MOTIVATION:

I've spent a good amount of time trying to figure it out the correct URL in order to reach a certain file on SharePoint!

This works:

https://mycompany.sharepoint.com/sites/site1/_api/web/GetFileByServerRelativeUrl('/sites/site1/myfile.xls')/$value

This doesn't:

https://mycompany.sharepoint.com/_api/web/GetFileByServerRelativeUrl('/sites/site1/myfile.xls')/$value

... and fails with 403 Status Code:

{
    "error": {
        "code": "-2147024891, System.UnauthorizedAccessException",
        "message": {
            "lang": "en-US",
            "value": "Attempted to perform an unauthorized operation."
        }
    }
}